### PR TITLE
Make `step.fetch` support custom retry header parsing logic

### DIFF
--- a/examples/fetch/src/index.ts
+++ b/examples/fetch/src/index.ts
@@ -25,7 +25,18 @@ export class MyWorkflow extends WorkflowEntrypoint<Env, Params> {
 			},
 			async (event, step) => {
 				// test server that 429 4 times, then 200 - see 429.py
-				const request = await step.fetch('get example', 'http://localhost:8080');
+				const request = await step.fetch('get example', 'http://localhost:8080', {
+					followRetryAfter: (headers) => {
+						const retryAfter = headers.get('Retry-After');
+						if (retryAfter) {
+							const maybeInt = parseInt(retryAfter, 10);
+							if (!isNaN(maybeInt)) {
+								return new Date(new Date().valueOf() + maybeInt * 1000);
+							}
+						}
+						return new Date();
+					},
+				});
 
 				console.log(request);
 

--- a/packages/core/src/lib.ts
+++ b/packages/core/src/lib.ts
@@ -70,7 +70,7 @@ interface DurableFetchConfig extends WorkflowStepConfig {
 	/**
 	 * Defaults to true, will checkout the `Retry-After` header and retry the request after the specified time.
 	 */
-	followRetryAfter?: boolean;
+	followRetryAfter?: boolean | ((headers: Headers) => Date);
 }
 
 interface DurableMapConfig extends WorkflowStepConfig {
@@ -497,6 +497,11 @@ export class FlowcesinhaContextBase<
 						}
 						return retryAfterDate;
 					}
+				}
+
+				if (typeof followRetryAfter === "function") {
+					const retryAfterDate = followRetryAfter(response.headers);
+					return retryAfterDate;
 				}
 
 				if (!response.ok) {


### PR DESCRIPTION
Add support for custom retry header parsing logic in `step.fetch`.

* Update `DurableFetchConfig` interface to allow a callback function for `followRetryAfter`.
* Modify `fetch` method to check if `followRetryAfter` is a function and use it to parse the retry header.
* Add logic to handle custom retry header parsing using the provided callback function.
* Update example in `examples/fetch/src/index.ts` to demonstrate the usage of the custom retry header parsing logic.